### PR TITLE
reclassify flow status after FLOW_TIMEOUT

### DIFF
--- a/pkt2flow.c
+++ b/pkt2flow.c
@@ -425,6 +425,21 @@ static void process_trace(void)
 				fname = new_file_name(af_6tuple, hdr.ts.tv_sec);
 				pair->pdf.file_name = fname;
 				pair->pdf.start_time = hdr.ts.tv_sec;
+
+				switch (af_6tuple.protocol) {
+				case IPPROTO_TCP:
+					if (syn_detected)
+						pair->pdf.status = STS_TCP_SYN;
+					else
+						pair->pdf.status = STS_TCP_NOSYN;
+					break;
+				case IPPROTO_UDP:
+					pair->pdf.status = STS_UDP;
+					break;
+				default:
+					pair->pdf.status = STS_UNSET;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
A flow which is marked as timeout and restarted again gets the status
STS_UNSET. This results in the output path "others/". This can often happen
with UDP packets like DHCP because they aren't send very frequenty. The
"others"/STS_UNSET classification is wrong in this case because it is known
that this flow is UDP. This is especially important when the "others" output
type is not enabled.

The flow should be reclassified instead to calculate the correct output folder.
